### PR TITLE
Admin: Inline double-confirm delete with toasts and animated removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Email-to-RSS keeps the same workflow while avoiding shared domains and shared da
 
 - One-click feed creation from an admin dashboard
 - Bulk feed/email deletion from the admin dashboard (safe checkbox-based flow)
+- Inline double-confirm delete interactions with toast feedback in the admin dashboard
 - Resizable + sortable table columns in the admin dashboard (Table view)
 - Unique newsletter addresses per feed (for example `apple.mountain.42@yourdomain.com`)
 - ForwardEmail webhook ingestion with source-IP verification

--- a/src/styles/components.ts
+++ b/src/styles/components.ts
@@ -834,6 +834,49 @@ export const componentStyles = `
     flex-wrap: wrap;
   }
 
+  .button-delete {
+    transition:
+      background-color 180ms ease,
+      border-color 180ms ease,
+      color 180ms ease,
+      transform 180ms ease,
+      box-shadow 180ms ease;
+  }
+
+  .button-delete.is-confirming {
+    background-color: rgba(255, 69, 58, 0.22);
+    border-color: rgba(255, 69, 58, 0.65);
+    color: #fff;
+    box-shadow: 0 12px 28px rgba(255, 69, 58, 0.18);
+    transform: translateY(-1px);
+  }
+
+  @media (prefers-color-scheme: light) {
+    .button-delete.is-confirming {
+      background-color: rgba(255, 69, 58, 0.12);
+      color: var(--color-text-primary);
+    }
+  }
+
+  .feed-row.is-removing,
+  .email-row.is-removing {
+    opacity: 0;
+    transform: translateY(-6px);
+    transition: opacity 200ms ease, transform 200ms ease;
+  }
+
+  .feed-item.is-removing {
+    opacity: 0;
+    transform: translateY(-6px);
+    overflow: hidden;
+    transition:
+      opacity 220ms ease,
+      transform 220ms ease,
+      max-height 220ms ease,
+      margin 220ms ease,
+      padding 220ms ease;
+  }
+
   /* Spinner (buttons + toasts) */
   @keyframes spin {
     to {


### PR DESCRIPTION
### Motivation
- Native browser `confirm()` dialogs were disruptive and broke the UX when deleting a feed or email; this change replaces them with an inline two-step confirmation flow that feels smoother and less disruptive.
- Provide immediate, robust feedback by using the existing toast system and animate rows out after a successful delete to make state changes obvious.
- Support AJAX-style admin interactions by returning JSON from delete endpoints when the client requests it so the UI can perform async deletes without full-page redirects.

### Description
- Replaced calls to `confirm()` for single-feed and single-email delete actions with inline two-step confirmation buttons that transform to a confirm state (transitions/animations applied) and perform an async JSON `POST` on second click (files: `src/routes/admin.ts`).
- Added client-side logic to show a loading spinner on the delete button while the async request is in flight, update toasts on success/failure, and animate the corresponding row/list item out on success (`setupFeedDeleteButtons`, `setupEmailDeleteButtons`, `animateRowRemoval`, `animateEmailRowRemoval`).
- Made server delete endpoints respond with JSON when the request `Accept` header includes `application/json` to support the new client-side flow (`/feeds/:feedId/delete`, `/emails/:emailKey/delete`).
- Improved the toast utility to support updating loading state and durations (`src/scripts/toast.ts`) and added CSS transitions/visual states for the confirm/confirming/delete animations (`src/styles/components.ts`).
- Hooked the new delete button behavior into admin UI initialization and added data attributes to delete buttons in list and table views to keep existing layout and flows intact (`src/routes/admin.ts`).
- Added unit tests exercising the JSON delete responses for both feed and email delete flows, and updated README to note the UX improvement (`src/routes/admin.test.ts`, `README.md`).

### Testing
- Ran the focused unit tests: `npm test -- src/routes/admin.test.ts`, resulting in 16 tests passing (all tests passed).
- No other automated test suites were modified; the change is constrained to admin UI/JS, toast behavior, styles, and the delete endpoints' JSON responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985b85a57a8832f823c96e221db265e)